### PR TITLE
RepositoryMiddleware buildRepository should be accessible from extend…

### DIFF
--- a/src/Middleware/RepositoryMiddleware.php
+++ b/src/Middleware/RepositoryMiddleware.php
@@ -32,7 +32,7 @@ class RepositoryMiddleware
 	 * @param \Illuminate\Http\Request $request
 	 * @return \Fuzz\MagicBox\EloquentRepository
 	 */
-	private function buildRepository(Request $request)
+	public function buildRepository(Request $request)
 	{
 		$input = [];
 		/** @var \Illuminate\Routing\Route $route */


### PR DESCRIPTION
To extend the public function handle in another class, $this->buildRepository needs to return an EloquentRepository to query based on your request parameters. 
